### PR TITLE
2 default snowflake roles eg accountadmin should be notinternalizable

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,14 +1,13 @@
 package main
 
 const (
-	SfAccount             = "sf-account"
-	SfUser                = "sf-user"
-	SfPassword            = "sf-password"
-	SfRole                = "sf-role"
-	SfDatabase            = "sf-database"
-	SfExcludedDatabases   = "sf-excluded-databases"
-	SfExcludedSchemas     = "sf-excluded-schemas"
-	SfExcludedOwners      = "sf-excluded-owners"
-	SfCreateFutureGrants  = "sf-create-future-grants"
-	SfExcludeDefaultRoles = "sf-exclude-default-roles"
+	SfAccount            = "sf-account"
+	SfUser               = "sf-user"
+	SfPassword           = "sf-password"
+	SfRole               = "sf-role"
+	SfDatabase           = "sf-database"
+	SfExcludedDatabases  = "sf-excluded-databases"
+	SfExcludedSchemas    = "sf-excluded-schemas"
+	SfExcludedOwners     = "sf-excluded-owners"
+	SfCreateFutureGrants = "sf-create-future-grants"
 )

--- a/constants.go
+++ b/constants.go
@@ -1,13 +1,14 @@
 package main
 
 const (
-	SfAccount = "sf-account"
-	SfUser = "sf-user"
-	SfPassword = "sf-password"
-	SfRole = "sf-role"
-	SfDatabase = "sf-database"
-	SfExcludedDatabases = "sf-excluded-databases"
-	SfExcludedSchemas = "sf-excluded-schemas"
-	SfExcludedOwners = "sf-excluded-owners"
-	SfCreateFutureGrants = "sf-create-future-grants"
+	SfAccount             = "sf-account"
+	SfUser                = "sf-user"
+	SfPassword            = "sf-password"
+	SfRole                = "sf-role"
+	SfDatabase            = "sf-database"
+	SfExcludedDatabases   = "sf-excluded-databases"
+	SfExcludedSchemas     = "sf-excluded-schemas"
+	SfExcludedOwners      = "sf-excluded-owners"
+	SfCreateFutureGrants  = "sf-create-future-grants"
+	SfExcludeDefaultRoles = "sf-exclude-default-roles"
 )

--- a/data_access.go
+++ b/data_access.go
@@ -29,7 +29,7 @@ var PermissionMap = map[string]PermissionTarget{
 	"WRITE": {snowflakePermissions: []string{"UPDATE", "INSERT", "DELETE"}, roleName: "W"},
 }
 
-var SNOWFLAKE_DEFAULT_ROLES = []string{"ACCOUNTADMIN", "USERADMIN", "ORGADMIN", "MASKING_ADMIN", "SECURITYADMIN", "SYSADMIN", "PUBLIC"}
+var SNOWFLAKE_DEFAULT_ROLES = []string{"ORGADMIN", "ACCOUNTADMIN", "SECURITYADMIN", "USERADMIN", "SYSADMIN", "PUBLIC"}
 
 const ROLE_SEPARATOR = "_"
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/blockloop/scan v1.3.0
 	github.com/hashicorp/go-hclog v1.0.0
 	github.com/raito-io/cli v0.6.0
+	github.com/raito-io/cli v0.7.1
 	github.com/snowflakedb/gosnowflake v1.6.5
 )
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/raito-io/cli/base"
 	"github.com/raito-io/cli/base/info"
@@ -21,15 +22,15 @@ func main() {
 			Name:    "Snowflake",
 			Version: api.ParseVersion(version),
 			Parameters: []api.ParameterInfo{
-				{ Name: "sf-account", Description: "The account name of the Snowflake account to connect to. For example, xy123456.eu-central-1", Mandatory: true},
-				{ Name: "sf-user", Description: "The username to authenticate against the Snowflake account.", Mandatory: true},
-				{ Name: "sf-password", Description: "The username to authenticate against the Snowflake account.", Mandatory: true},
-				{ Name: "sf-role", Description: "The name of the role to use for executing the necessary queries. If not specified 'ACCOUNTADMIN' is used.", Mandatory: false},
-				{ Name: "sf-database", Description: "The name of the main database to connect to. This is necessary for building the connection string.", Mandatory: true},
-				{ Name: "sf-excluded-databases", Description: "The optional comma-separated list of databases that should be skipped.", Mandatory: false},
-				{ Name: "sf-excluded-schemas", Description: "The optional comma-separated list of schemas that should be skipped. This can either be in a specific database (as <database>.<schema>) or a just a schema name that should be skipped in all databases.", Mandatory: false},
-				{ Name: "sf-excluded-owners", Description: "The optional comma-separated list of owners that need to be skipped when syncing users. This is typically  used to not synchronize the users that were imported from an external Identity Store (like Okta, Active Directory, ...).", Mandatory: false},
-				{ Name: "sf-create-future-grants", Description: "If set, future grants will be created for all the created grants. This may lead to a less controlled situation, so only use when you are sure.", Mandatory: false},
+				{Name: "sf-account", Description: "The account name of the Snowflake account to connect to. For example, xy123456.eu-central-1", Mandatory: true},
+				{Name: "sf-user", Description: "The username to authenticate against the Snowflake account.", Mandatory: true},
+				{Name: "sf-password", Description: "The username to authenticate against the Snowflake account.", Mandatory: true},
+				{Name: "sf-role", Description: "The name of the role to use for executing the necessary queries. If not specified 'ACCOUNTADMIN' is used.", Mandatory: false},
+				{Name: "sf-database", Description: "The name of the main database to connect to. This is necessary for building the connection string.", Mandatory: true},
+				{Name: "sf-excluded-databases", Description: "The optional comma-separated list of databases that should be skipped.", Mandatory: false},
+				{Name: "sf-excluded-schemas", Description: "The optional comma-separated list of schemas that should be skipped. This can either be in a specific database (as <database>.<schema>) or a just a schema name that should be skipped in all databases.", Mandatory: false},
+				{Name: "sf-excluded-owners", Description: "The optional comma-separated list of owners that need to be skipped when syncing users or marked as read-only when importing roles as Access Providers. This is typically  used to not synchronize the users that were imported from an external Identity Store (like Okta, Active Directory, ...).", Mandatory: false},
+				{Name: "sf-create-future-grants", Description: "If set, future grants will be created for all the created grants. This may lead to a less controlled situation, so only use when you are sure.", Mandatory: false},
 			},
 		},
 	})


### PR DESCRIPTION
- Implemented role inheritance. When a role is granted to another role, the access rights are automatically transfered
- When importing, a set of default snowflake roles is always notInternalizable. Also added a config option to skip their import
