### PR TITLE
Revert pointer change from previous PR, fix some linter warnings.

### DIFF
--- a/data_access.go
+++ b/data_access.go
@@ -366,7 +366,8 @@ func (s *DataAccessSyncer) importPoliciesOfType(config *data_access.DataAccessSy
 			}
 		}
 
-		for _, policyReference := range policyReferenceEntities {
+		for ind := range policyReferenceEntities {
+			policyReference := policyReferenceEntities[ind]
 			if !strings.EqualFold("Active", policyReference.POLICY_STATUS) {
 				continue
 			}

--- a/data_usage.go
+++ b/data_usage.go
@@ -107,7 +107,7 @@ func (s *DataUsageSyncer) SyncDataUsage(config *data_usage.DataUsageSyncConfig) 
 		}
 
 		logger.Info("Scanning query results for batch %d", currentBatch)
-		var returnedRows []*queryDbEntities
+		var returnedRows []queryDbEntities
 		err = scan.Rows(&returnedRows, rows)
 
 		if err != nil {
@@ -121,8 +121,10 @@ func (s *DataUsageSyncer) SyncDataUsage(config *data_usage.DataUsageSyncConfig) 
 		timeFormat := "2006-01-02T15:04:05.999999-07:00"
 		executedStatements := make([]dub.Statement, 0, 20)
 
-		for _, returnedRow := range returnedRows {
+		for ind := range returnedRows {
+			returnedRow := returnedRows[ind]
 			startTime, e := time.Parse(timeFormat, returnedRow.StartTime)
+
 			if e != nil {
 				logger.Error(fmt.Sprintf("Error parsing start time of '%s', expected format is: '%s'", returnedRow.StartTime, timeFormat))
 			}


### PR DESCRIPTION
Data usage sync wasn't working anymore after the Go upgrade PR (due to a change suggested by the linter apparently). 