### PR TITLE
feature/global-97. Retrieve data from last 14 days.

### DIFF
--- a/data_usage.go
+++ b/data_usage.go
@@ -54,8 +54,8 @@ func (s *DataUsageSyncer) SyncDataUsage(config *data_usage.DataUsageSyncConfig) 
 	const numRowsPerBatch = 10000
 	queryHistoryTable := "SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY"
 
-	// TODO: should be configurable
-	numberOfDays := 7
+	// TODO[LATER]: number of days should be configurable
+	numberOfDays := 14
 	startDate := time.Now().AddDate(0, 0, -numberOfDays)
 	dateFormat := "2006-01-02"
 	filterClause := fmt.Sprintf("WHERE start_time >= '%s'", startDate.Format(dateFormat))


### PR DESCRIPTION
Retrieve data from the last 14 days by default. 

Follow-up issue: https://github.com/raito-io/global/issues/79. Actually poll the appserver to see from how long ago the data needs to be retrieved. 