### PR TITLE
remove sf-database as parameter from connection string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,7 @@ __debug_bin
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-cli-plugin-snowflake
+cli-plugin-snowflake*
 local*.sh
+raito*.yml
+raito*.json

--- a/constants.go
+++ b/constants.go
@@ -5,7 +5,6 @@ const (
 	SfUser              = "sf-user"
 	SfPassword          = "sf-password"
 	SfRole              = "sf-role"
-	SfDatabase          = "sf-database"
 	SfExcludedDatabases = "sf-excluded-databases"
 	SfExcludedSchemas   = "sf-excluded-schemas"
 	SfExcludedOwners    = "sf-excluded-owners"

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ func main() {
 				{Name: "sf-user", Description: "The username to authenticate against the Snowflake account.", Mandatory: true},
 				{Name: "sf-password", Description: "The username to authenticate against the Snowflake account.", Mandatory: true},
 				{Name: "sf-role", Description: "The name of the role to use for executing the necessary queries. If not specified 'ACCOUNTADMIN' is used.", Mandatory: false},
-				{Name: "sf-database", Description: "The name of the main database to connect to. This is necessary for building the connection string.", Mandatory: true},
 				{Name: "sf-excluded-databases", Description: "The optional comma-separated list of databases that should be skipped.", Mandatory: false},
 				{Name: "sf-excluded-schemas", Description: "The optional comma-separated list of schemas that should be skipped. This can either be in a specific database (as <database>.<schema>) or a just a schema name that should be skipped in all databases.", Mandatory: false},
 				{Name: "sf-excluded-owners", Description: "The optional comma-separated list of owners that need to be skipped when syncing users or marked as read-only when importing roles as Access Providers. This is typically  used to not synchronize the users that were imported from an external Identity Store (like Okta, Active Directory, ...).", Mandatory: false},

--- a/snowflake.go
+++ b/snowflake.go
@@ -16,20 +16,15 @@ func ConnectToSnowflake(params map[string]interface{}, role string) (*sql.DB, er
 	if snowflakeUser == nil {
 		return nil, e.CreateMissingInputParameterError(SfUser)
 	}
-	snowflakePassword := params[SfPassword]
 
+	snowflakePassword := params[SfPassword]
 	if snowflakePassword == nil {
 		return nil, e.CreateMissingInputParameterError(SfPassword)
 	}
-	snowflakeAccount := params[SfAccount]
 
+	snowflakeAccount := params[SfAccount]
 	if snowflakeAccount == nil {
 		return nil, e.CreateMissingInputParameterError(SfAccount)
-	}
-	snowflakeDatabase := params[SfDatabase]
-
-	if snowflakeDatabase == nil {
-		return nil, e.CreateMissingInputParameterError(SfDatabase)
 	}
 
 	if role == "" {
@@ -44,12 +39,13 @@ func ConnectToSnowflake(params map[string]interface{}, role string) (*sql.DB, er
 
 	urlUser := url.UserPassword(snowflakeUser.(string), snowflakePassword.(string))
 
-	connectionString := fmt.Sprintf("%s@%s/%s?role=%s", urlUser, snowflakeAccount, snowflakeDatabase, role)
-	logger.Debug(fmt.Sprintf("Using connection string: %s:%s@%s/%s?role=%s", snowflakeUser, "**censured**", snowflakeAccount, snowflakeDatabase, role))
+	connectionString := fmt.Sprintf("%s@%s?role=%s", urlUser, snowflakeAccount, role)
+	censoredConnectionString := fmt.Sprintf("%s:%s@%s?role=%s", snowflakeUser, "**censured**", snowflakeAccount, role)
+	logger.Debug(fmt.Sprintf("Using connection string: %s", censoredConnectionString))
 	conn, err := sql.Open("snowflake", connectionString)
 
 	if err != nil {
-		return nil, e.CreateSourceConnectionError(fmt.Sprintf("%s:%s@%s/%s?role=%s", snowflakeUser, "**censured**", snowflakeAccount, snowflakeDatabase, role), err.Error())
+		return nil, e.CreateSourceConnectionError(censoredConnectionString, err.Error())
 	}
 
 	return conn, nil


### PR DESCRIPTION
I checked whether we can remove the 'database' from the connection string. It's not always logical to have to provide it. 

The Snowflake connection is working fine locally. 

~~Disclaimer: I tried running a full CLI sync locally, but it doesn't seem to be working anymore. Getting this error after all data objects have been pulled in~~ (never mind, was using a 2-week old, locally-compiled version)

Implements issue: https://github.com/raito-io/cli-plugin-snowflake/issues/40