### PR TITLE
description and comments updates

### DIFF
--- a/common/snowflake_parser.go
+++ b/common/snowflake_parser.go
@@ -25,7 +25,7 @@ func (s SnowflakeObject) GetFullName(withQuotes bool) string {
 		return fullName
 	}
 
-	fullName = fmt.Sprintf(convertToValidSnowflakeResource(*s.Database, withQuotes))
+	fullName = convertToValidSnowflakeResource(*s.Database, withQuotes)
 
 	if s.Schema == nil {
 		return fullName
@@ -55,6 +55,7 @@ func convertToValidSnowflakeResource(name string, withQuotes bool) string {
 
 	if withQuotes {
 		name = strings.ReplaceAll(name, `"`, `""`)
+		//nolint // %q would break correct formatting for Unicode characters
 		name = fmt.Sprintf(`"%s"`, name)
 	}
 
@@ -69,7 +70,7 @@ func isSimpleSnowflakeName(name string) bool {
 	startRegex := regexp.MustCompile("[a-zA-Z_]")
 	contentRegex := regexp.MustCompile("[a-zA-Z0-9_$]")
 
-	if len(startRegex.ReplaceAllString(fmt.Sprintf("%c", name[0]), "")) != 0 {
+	if startRegex.ReplaceAllString(fmt.Sprintf("%c", name[0]), "") != "" {
 		return false
 	}
 

--- a/common/snowflake_parser_test.go
+++ b/common/snowflake_parser_test.go
@@ -15,19 +15,24 @@ func TestFullNameWithoutSpecialChars(t *testing.T) {
 
 	object := SnowflakeObject{&databaseName, nil, nil, nil}
 	assert.Equal(t, "db", object.GetFullName(false))
-	assert.Equal(t, `"db"`, object.GetFullName(true))
+	assert.Equal(t, `db`, object.GetFullName(true))
 
 	object.Schema = &schemaName
 	assert.Equal(t, "db.schema", object.GetFullName(false))
-	assert.Equal(t, `"db"."schema"`, object.GetFullName(true))
+	assert.Equal(t, `db.schema`, object.GetFullName(true))
 
 	object.Table = &tableName
 	assert.Equal(t, "db.schema.table", object.GetFullName(false))
-	assert.Equal(t, `"db"."schema"."table"`, object.GetFullName(true))
+	assert.Equal(t, `db.schema.table`, object.GetFullName(true))
 
 	object.Column = &columnName
 	assert.Equal(t, "db.schema.table.column", object.GetFullName(false))
-	assert.Equal(t, `"db"."schema"."table"."column"`, object.GetFullName(true))
+	assert.Equal(t, `db.schema.table.column`, object.GetFullName(true))
+
+	columnName = `column"_$123`
+	object.Column = &columnName
+	assert.Equal(t, `db.schema.table.column"_$123`, object.GetFullName(false))
+	assert.Equal(t, `db.schema.table."column""_$123"`, object.GetFullName(true))
 }
 
 func TestFullNameWithSpecialChars(t *testing.T) {

--- a/common/snowflake_parser_test.go
+++ b/common/snowflake_parser_test.go
@@ -209,3 +209,21 @@ func TestFindNextQuote(t *testing.T) {
 	res = findNextStandaloneChar(`d ""kdkddf."`, `"`)
 	assert.Equal(t, 11, res)
 }
+
+func TestSimpleSnowflakeName(t *testing.T) {
+	var test []string
+
+	// simple names
+	test = []string{"abcd", "_ab_cd", "AAA_ab_cd"}
+
+	for _, testName := range test {
+		assert.True(t, isSimpleSnowflakeName(testName))
+	}
+
+	// non-simple names
+	test = []string{"12AAA_ab_cd", "AAAA!", "test-this", `"tst_something`}
+
+	for _, testName := range test {
+		assert.False(t, isSimpleSnowflakeName(testName))
+	}
+}

--- a/data_access.go
+++ b/data_access.go
@@ -1206,6 +1206,7 @@ func createComment(ap *importer.AccessProvider, update bool) string {
 	if update {
 		action = "Updated"
 	}
+
 	return fmt.Sprintf("%s by Raito from access provider %s. %s", action, ap.Name, ap.Description)
 }
 

--- a/data_source.go
+++ b/data_source.go
@@ -193,12 +193,16 @@ func addDbEntitiesToImporter(fileCreator ds.DataSourceFileCreator, conn *sql.DB,
 
 		fullName := externalIdGenerator(db.Name)
 		if filter(db.Name, fullName) {
+			comment := ""
+			if db.Comment != nil {
+				comment = *db.Comment
+			}
 			do := ds.DataObject{
 				ExternalId:       fullName,
 				Name:             db.Name,
 				FullName:         fullName,
 				Type:             doType,
-				Description:      "",
+				Description:      comment,
 				ParentExternalId: parent,
 			}
 			dataObjects = append(dataObjects, do)
@@ -305,7 +309,8 @@ func readColumns(fileCreator ds.DataSourceFileCreator, conn *sql.DB, doTypePrefi
 }
 
 type dbEntity struct {
-	Name string `db:"name"`
+	Name    string  `db:"name"`
+	Comment *string `db:"comment"`
 }
 
 func (s *DataSourceSyncer) GetMetaData() ds.MetaData {


### PR DESCRIPTION
Closes
- https://github.com/raito-io/global/issues/161 
- https://github.com/raito-io/cli-plugin-snowflake/issues/48

Still WIP
- part of https://github.com/raito-io/cli/issues/83. Import of data objects with double quotes in their name is implemented. But for the rest, it seems I wasn't running the latest version of the appserver (or didn't have the right test scenario), and more updates are needed now, also for Unicode. See last comments: https://github.com/raito-io/cli/issues/83



