### PR TITLE
Cli 83 unicode continued

### DIFF
--- a/common/snowflake_parser.go
+++ b/common/snowflake_parser.go
@@ -86,9 +86,11 @@ func FormatQuery(query string, objects ...string) string {
 	newObjects := []interface{}{}
 
 	for ind := range objects {
-		objects[ind] = strings.ReplaceAll(objects[ind], `"`, `""`)
-		//nolint // this interferes with proper formatting
-		objects[ind] = fmt.Sprintf(`"%s"`, objects[ind])
+		formattedObject := objects[ind]
+		if !isSimpleSnowflakeName(formattedObject) {
+			objects[ind] = fmt.Sprintf(`"%s"`, strings.ReplaceAll(objects[ind], `"`, `""`))
+		}
+		objects[ind] = formattedObject
 		newObjects = append(newObjects, objects[ind])
 	}
 

--- a/common/snowflake_parser.go
+++ b/common/snowflake_parser.go
@@ -74,7 +74,7 @@ func isSimpleSnowflakeName(name string) bool {
 		return false
 	}
 
-	if len(contentRegex.ReplaceAllString(name, "")) > 0 {
+	if contentRegex.ReplaceAllString(name, "") != "" {
 		return false
 	}
 
@@ -85,13 +85,12 @@ func isSimpleSnowflakeName(name string) bool {
 func FormatQuery(query string, objects ...string) string {
 	newObjects := []interface{}{}
 
-	for ind := range objects {
-		formattedObject := objects[ind]
+	for _, obj := range objects {
+		formattedObject := obj
 		if !isSimpleSnowflakeName(formattedObject) {
-			objects[ind] = fmt.Sprintf(`"%s"`, strings.ReplaceAll(objects[ind], `"`, `""`))
+			formattedObject = fmt.Sprintf(`"%s"`, strings.ReplaceAll(formattedObject, `"`, `""`))
 		}
-		objects[ind] = formattedObject
-		newObjects = append(newObjects, objects[ind])
+		newObjects = append(newObjects, formattedObject)
 	}
 
 	return fmt.Sprintf(query, newObjects...)

--- a/common/snowflake_parser.go
+++ b/common/snowflake_parser.go
@@ -88,8 +88,10 @@ func FormatQuery(query string, objects ...string) string {
 	for _, obj := range objects {
 		formattedObject := obj
 		if !isSimpleSnowflakeName(formattedObject) {
+			//nolint // Using %q would interfere with the required formatting
 			formattedObject = fmt.Sprintf(`"%s"`, strings.ReplaceAll(formattedObject, `"`, `""`))
 		}
+
 		newObjects = append(newObjects, formattedObject)
 	}
 

--- a/common/snowflake_parser_test.go
+++ b/common/snowflake_parser_test.go
@@ -226,7 +226,7 @@ func TestSimpleSnowflakeName(t *testing.T) {
 	}
 
 	// non-simple names
-	test = []string{"12AAA_ab_cd", "AAAA!", "test-this", `"tst_something`}
+	test = []string{"12AAA_ab_cd", "AAAA!", "test-this", `"tst_something`, `testRole"."Yes!`}
 
 	for _, testName := range test {
 		assert.False(t, isSimpleSnowflakeName(testName))

--- a/data_access.go
+++ b/data_access.go
@@ -922,6 +922,7 @@ func (s *AccessSyncer) getGrantsOfRole(rn string, conn *sql.DB) ([]grantOfRole, 
 }
 
 func createGrantsForTable(permissions []string, fullName string) ([]interface{}, error) {
+	// TODO: this does not work for Raito full names
 	sfObject := common.ParseFullName(fullName)
 	if sfObject.Database == nil || sfObject.Schema == nil || sfObject.Table == nil {
 		return nil, fmt.Errorf("expected fullName %q to have 3 parts (database.schema.table)", fullName)
@@ -940,6 +941,7 @@ func createGrantsForTable(permissions []string, fullName string) ([]interface{},
 }
 
 func createGrantsForView(permissions []string, fullName string) ([]interface{}, error) {
+	// TODO: this does not work for Raito full names
 	sfObject := common.ParseFullName(fullName)
 	if sfObject.Database == nil || sfObject.Schema == nil || sfObject.Table == nil {
 		return nil, fmt.Errorf("expected fullName %q to have 3 parts (database.schema.view)", fullName)
@@ -958,6 +960,7 @@ func createGrantsForView(permissions []string, fullName string) ([]interface{}, 
 }
 
 func createGrantsForSchema(conn *sql.DB, permissions []string, fullName string) ([]interface{}, error) {
+	// TODO: this does not work for Raito full names
 	sfObject := common.ParseFullName(fullName)
 	if sfObject.Database == nil || sfObject.Schema == nil {
 		return nil, fmt.Errorf("expected fullName %q to have 2 parts (database.schema)", fullName)

--- a/data_access.go
+++ b/data_access.go
@@ -922,59 +922,57 @@ func (s *AccessSyncer) getGrantsOfRole(rn string, conn *sql.DB) ([]grantOfRole, 
 }
 
 func createGrantsForTable(permissions []string, fullName string) ([]interface{}, error) {
-	// TODO. What if there's a dot in one of the data objects' names?
-	parts := strings.Split(fullName, ".")
-	if len(parts) != 3 {
+	sfObject := common.ParseFullName(fullName)
+	if sfObject.Database == nil || sfObject.Schema == nil || sfObject.Table == nil {
 		return nil, fmt.Errorf("expected fullName %q to have 3 parts (database.schema.table)", fullName)
 	}
 
 	grants := make([]interface{}, 0, len(permissions)+2)
 	grants = append(grants,
-		Grant{"USAGE", common.FormatQuery(`DATABASE %s`, parts[0])},
-		Grant{"USAGE", common.FormatQuery(`SCHEMA %s.%s`, parts[0], parts[1])})
+		Grant{"USAGE", common.FormatQuery(`DATABASE %s`, *sfObject.Database)},
+		Grant{"USAGE", common.FormatQuery(`SCHEMA %s.%s`, *sfObject.Database, *sfObject.Schema)})
 
 	for _, p := range permissions {
-		grants = append(grants, Grant{p, common.FormatQuery(`TABLE %s.%s.%s`, parts[0], parts[1], parts[2])})
+		grants = append(grants, Grant{p, common.FormatQuery(`TABLE %s.%s.%s`, *sfObject.Database, *sfObject.Schema, *sfObject.Table)})
 	}
 
 	return grants, nil
 }
 
 func createGrantsForView(permissions []string, fullName string) ([]interface{}, error) {
-	// TODO. What if there's a dot in one of the data objects' names? - use fullName parsing here as well
-	parts := strings.Split(fullName, ".")
-	if len(parts) != 3 {
+	sfObject := common.ParseFullName(fullName)
+	if sfObject.Database == nil || sfObject.Schema == nil || sfObject.Table == nil {
 		return nil, fmt.Errorf("expected fullName %q to have 3 parts (database.schema.view)", fullName)
 	}
 
 	grants := make([]interface{}, 0, len(permissions)+2)
 	grants = append(grants,
-		Grant{"USAGE", common.FormatQuery(`DATABASE %s`, parts[0])},
-		Grant{"USAGE", common.FormatQuery(`SCHEMA %s.%s`, parts[0], parts[1])})
+		Grant{"USAGE", common.FormatQuery(`DATABASE %s`, *sfObject.Database)},
+		Grant{"USAGE", common.FormatQuery(`SCHEMA %s.%s`, *sfObject.Database, *sfObject.Schema)})
 
 	for _, p := range permissions {
-		grants = append(grants, Grant{p, common.FormatQuery(`VIEW %s.%s.%s`, parts[0], parts[1], parts[2])})
+		grants = append(grants, Grant{p, common.FormatQuery(`VIEW %s.%s.%s`, *sfObject.Database, *sfObject.Schema, *sfObject.Table)})
 	}
 
 	return grants, nil
 }
 
 func createGrantsForSchema(conn *sql.DB, permissions []string, fullName string) ([]interface{}, error) {
-	parts := strings.Split(fullName, ".")
-	if len(parts) != 2 {
+	sfObject := common.ParseFullName(fullName)
+	if sfObject.Database == nil || sfObject.Schema == nil {
 		return nil, fmt.Errorf("expected fullName %q to have 2 parts (database.schema)", fullName)
 	}
 
-	q := common.FormatQuery(`SHOW TABLES IN SCHEMA %s.%s`, parts[0], parts[1])
+	q := common.FormatQuery(`SHOW TABLES IN SCHEMA %s.%s`, *sfObject.Database, *sfObject.Schema)
 	tables, _ := readDbEntities(conn, q)
 	grants := make([]interface{}, 0, (len(permissions)*len(tables))+2)
 	grants = append(grants,
-		Grant{"USAGE", common.FormatQuery(`DATABASE %s`, parts[0])},
-		Grant{"USAGE", common.FormatQuery(`SCHEMA %s.%s`, parts[0], parts[1])})
+		Grant{"USAGE", common.FormatQuery(`DATABASE %s`, *sfObject.Database)},
+		Grant{"USAGE", common.FormatQuery(`SCHEMA %s.%s`, *sfObject.Database, *sfObject.Schema)})
 
 	for _, table := range tables {
 		for _, p := range permissions {
-			grants = append(grants, Grant{p, common.FormatQuery(`TABLE %s.%s.%s`, parts[0], parts[1], table.Name)})
+			grants = append(grants, Grant{p, common.FormatQuery(`TABLE %s.%s.%s`, *sfObject.Database, *sfObject.Schema, table.Name)})
 		}
 	}
 

--- a/identity_store.go
+++ b/identity_store.go
@@ -64,15 +64,15 @@ func (s *IdentityStoreSyncer) SyncIdentityStore(config *is.IdentityStoreSyncConf
 	users := make([]is.User, 0, 20)
 
 	for _, userRow := range userRows {
-		logger.Debug(fmt.Sprintf("Handling user %q", userRow.UserName))
+		logger.Debug(fmt.Sprintf("Handling user %q", userRow.Name))
 
 		if _, f := ownerExclusions[userRow.Owner]; f {
 			logger.Debug("Skipping user as it's owned by an excluded owner")
 			continue
 		}
 		user := is.User{
-			ExternalId: userRow.UserName,
-			UserName:   userRow.UserName,
+			ExternalId: userRow.LoginName,
+			UserName:   userRow.Name,
 			Name:       userRow.DisplayName,
 			Email:      userRow.Email,
 		}
@@ -94,7 +94,8 @@ func (s *IdentityStoreSyncer) SyncIdentityStore(config *is.IdentityStoreSyncConf
 }
 
 type userEntity struct {
-	UserName    string `db:"login_name"`
+	Name        string `db:"name"`
+	LoginName   string `db:"login_name"`
 	DisplayName string `db:"display_name"`
 	Email       string `db:"email"`
 	Owner       string `db:"owner"`


### PR DESCRIPTION
Fixes most of the unicode/quotes issues
- Had to refactor the user import (which SF user field is mapped to what Raito property), see https://github.com/raito-io/cli/issues/83#issuecomment-1265215273


Remaining issues
- Even though you can create user with double quotes in SF, I haven't found a way to log in for such a user (if the 'login_name' also contains double quotes), e.g. `{"name": "aaa\".\"User", "login_name": "AAA\".\"USER", "display_name": "aaa\".\"User"}`
- Through the use of our 'full name' field in Raito, we lose information. E.g. "database.schema.name1.name2" could refer to `{"database": "database", "schema": "schema", "table": "name1.name2"}` or `{"database": "database", "schema": "schema", "table": "name1", "column": "name2"}`, or other combinations. The Snowflake formatting rules, while cumbersome, are fully reversible, whereas ours are not. At this point it's not possible to correctly import a Snowflake role that is assigned to data objects with a dot in the name. The solution would be to use similar formatting rules in our Graph as Snowflake (fields with a dot should be enclosed by double quotes, single double quotes are transformed to double double quotes). 