### PR TITLE
Bugfix/row access policies standard edition

### DIFF
--- a/snowflake/data_access.go
+++ b/snowflake/data_access.go
@@ -384,8 +384,8 @@ func (s *AccessSyncer) importAccessForRole(roleEntity RoleEntity, ownersToExclud
 func (s *AccessSyncer) importPoliciesOfType(accessProviderHandler wrappers.AccessProviderHandler, repo dataAccessRepository, policyType string, action exporter.Action) error {
 	policyEntities, err := repo.GetPolicies(policyType)
 	if err != nil {
-		// For standard edition, row access policies are not supported.
-		// You can see you Snowflake edition in the UI, or through the 'show organization accounts;' query (ORGADMIN role needed).
+		// For Standard edition, row access policies are not supported. Failsafe in case `sf-standard-edition` is overlooked.
+		// You can see the Snowflake edition in the UI, or through the 'show organization accounts;' query (ORGADMIN role needed).
 		if strings.Contains(err.Error(), "Unsupported feature") {
 			logger.Warn(fmt.Sprintf("Could not fetch policies of type %s; unsupported feature.", policyType))
 		} else {

--- a/snowflake/data_access.go
+++ b/snowflake/data_access.go
@@ -384,7 +384,13 @@ func (s *AccessSyncer) importAccessForRole(roleEntity RoleEntity, ownersToExclud
 func (s *AccessSyncer) importPoliciesOfType(accessProviderHandler wrappers.AccessProviderHandler, repo dataAccessRepository, policyType string, action exporter.Action) error {
 	policyEntities, err := repo.GetPolicies(policyType)
 	if err != nil {
-		return fmt.Errorf("error fetching all %s policies: %s", policyType, err.Error())
+		// For standard edition, row access policies are not supported.
+		// You can see you Snowflake edition in the UI, or through the 'show organization accounts;' query (ORGADMIN role needed).
+		if strings.Contains(err.Error(), "Unsupported feature") {
+			logger.Warn(fmt.Sprintf("Could not fetch policies of type %s; unsupported feature.", policyType))
+		} else {
+			return fmt.Errorf("error fetching all %s policies: %s", policyType, err.Error())
+		}
 	}
 
 	for _, policy := range policyEntities {

--- a/snowflake/data_access_test.go
+++ b/snowflake/data_access_test.go
@@ -234,7 +234,6 @@ func TestAccessSyncer_SyncAccessProvidersFromTarget_StandardEdition(t *testing.T
 	repoMock.EXPECT().GetGrantsToRole("Role3").Return([]GrantToRole{
 		{GrantedOn: "GrandOnRole3Number1", Name: "GranteeRole3", Privilege: "WRITE"},
 	}, nil).Once()
-	repoMock.EXPECT().GetPolicies("ROW ACCESS").Return(nil, fmt.Errorf("error: 000002 (0A000): Unsupported feature 'ROW ACCESS POLICY'.")).Once()
 
 	syncer := &AccessSyncer{
 		repoProvider: func(params map[string]interface{}, role string) (dataAccessRepository, error) {

--- a/snowflake/data_access_test.go
+++ b/snowflake/data_access_test.go
@@ -234,6 +234,7 @@ func TestAccessSyncer_SyncAccessProvidersFromTarget_StandardEdition(t *testing.T
 	repoMock.EXPECT().GetGrantsToRole("Role3").Return([]GrantToRole{
 		{GrantedOn: "GrandOnRole3Number1", Name: "GranteeRole3", Privilege: "WRITE"},
 	}, nil).Once()
+	repoMock.EXPECT().GetPolicies("ROW ACCESS").Return(nil, fmt.Errorf("error: 000002 (0A000): Unsupported feature 'ROW ACCESS POLICY'.")).Once()
 
 	syncer := &AccessSyncer{
 		repoProvider: func(params map[string]interface{}, role string) (dataAccessRepository, error) {


### PR DESCRIPTION
Technically this is not needed, because you should set the 'sf-standard-edition' flag, but I didn't know about that flag (https://github.com/raito-io/raito-io.github.io/pull/35) and so the import was failing for a Standard edition Snowflake instance on Access Provider import. 

I think it's a good failsafe to have right now. If they ever change the error message, we still have the documentation as the correct way to do things. 