### PR TITLE
fix double quotes in user input

### DIFF
--- a/snowflake/data_access.go
+++ b/snowflake/data_access.go
@@ -290,14 +290,9 @@ func (s *AccessSyncer) importAccessForRole(roleEntity RoleEntity, externalGroupO
 
 		for _, grantee := range grantOfEntities {
 			if grantee.GrantedTo == "USER" {
-				users = append(users, grantee.GranteeName)
+				users = append(users, cleanDoubleQuotes(grantee.GranteeName))
 			} else if grantee.GrantedTo == "ROLE" {
-				ap := grantee.GranteeName
-				if strings.HasPrefix(ap, "\"") && strings.HasSuffix(ap, "\"") {
-					ap = ap[1 : len(ap)-1]
-				}
-
-				accessProviders = append(accessProviders, ap)
+				accessProviders = append(accessProviders, cleanDoubleQuotes(grantee.GranteeName))
 			}
 		}
 	}

--- a/snowflake/identity_store.go
+++ b/snowflake/identity_store.go
@@ -79,9 +79,9 @@ func (s *IdentityStoreSyncer) SyncIdentityStore(ctx context.Context, identityHan
 		}
 
 		user := is.User{
-			ExternalId: userRow.LoginName,
-			UserName:   userRow.Name,
-			Name:       displayName,
+			ExternalId: cleanDoubleQuotes(userRow.LoginName),
+			UserName:   cleanDoubleQuotes(userRow.Name),
+			Name:       cleanDoubleQuotes(displayName),
 			Email:      userRow.Email,
 		}
 
@@ -92,4 +92,12 @@ func (s *IdentityStoreSyncer) SyncIdentityStore(ctx context.Context, identityHan
 	}
 
 	return nil
+}
+
+func cleanDoubleQuotes(input string) string {
+	if len(input) > 0 && strings.HasPrefix(input, "\"") && strings.HasSuffix(input, "\"") {
+		return input[1 : len(input)-1]
+	}
+
+	return input
 }

--- a/snowflake/identity_store.go
+++ b/snowflake/identity_store.go
@@ -93,11 +93,3 @@ func (s *IdentityStoreSyncer) SyncIdentityStore(ctx context.Context, identityHan
 
 	return nil
 }
-
-func cleanDoubleQuotes(input string) string {
-	if len(input) > 0 && strings.HasPrefix(input, "\"") && strings.HasSuffix(input, "\"") {
-		return input[1 : len(input)-1]
-	}
-
-	return input
-}

--- a/snowflake/utils.go
+++ b/snowflake/utils.go
@@ -1,6 +1,8 @@
 package snowflake
 
 import (
+	"strings"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/raito-io/cli/base"
 )
@@ -9,4 +11,12 @@ var logger hclog.Logger
 
 func init() {
 	logger = base.Logger()
+}
+
+func cleanDoubleQuotes(input string) string {
+	if len(input) >= 2 && strings.HasPrefix(input, "\"") && strings.HasSuffix(input, "\"") {
+		return input[1 : len(input)-1]
+	}
+
+	return input
 }

--- a/snowflake/utils_test.go
+++ b/snowflake/utils_test.go
@@ -1,0 +1,26 @@
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUtils_CleanDoubleQuotes(t *testing.T) {
+	inputExpectedMap := map[string]string{}
+
+	inputExpectedMap[""] = ""
+	inputExpectedMap["\"Test User\""] = "Test User"
+	inputExpectedMap["\"Test User"] = "\"Test User"
+	inputExpectedMap["Test User\""] = "Test User\""
+	inputExpectedMap["TEst \"User\" Something"] = "TEst \"User\" Something"
+	inputExpectedMap["\""] = "\""
+	inputExpectedMap["\"a"] = "\"a"
+	inputExpectedMap["b\""] = "b\""
+	inputExpectedMap["\"\"Test User\"\""] = "\"Test User\""
+	inputExpectedMap["\"AP.WiTh_Dots.And.More-\""] = "AP.WiTh_Dots.And.More-"
+
+	for k, v := range inputExpectedMap {
+		assert.Equal(t, v, cleanDoubleQuotes(k))
+	}
+}


### PR DESCRIPTION
It seems there's nothing we can do besides the fix that was already pushed. 

```{"externalId":"another.test.role","name":"another.test.role","namingHint":"another.test.role","access":null,"action":"Grant","policy":"","who":{"users":["MACWILLIAM_J","TEst.User.One","Test Engineer ©"],"groups":[],"accessProviders":["\"TEST.ROLE.FOR.Test.ENGINEER\""]},"notInternalizable":false,"whoLocked":null,"whoLockedReason":null,"whatLocked":null,"whatLockedReason":null,"nameLocked":null,"nameLockedReason":null,"deleteLocked":null,"deleteLockedReason":null,"actualName":"another.test.role","what":[]}```

`grantee.GranteeName` just behaves differently for users or access providers. 

I noticed there was some irregularity with the users as well (this PR). 