### PR TITLE
add ownership before commenting

### DIFF
--- a/snowflake/data_access.go
+++ b/snowflake/data_access.go
@@ -59,7 +59,7 @@ type dataAccessRepository interface {
 	GetTablesInDatabase(databaseName string, schemaName string, handleEntity EntityHandler) error
 	GetViewsInDatabase(databaseName string, schemaName string, handleEntity EntityHandler) error
 	GetSchemasInDatabase(databaseName string, handleEntity EntityHandler) error
-	CommentIfExists(comment, objectType, objectName string) error
+	CommentRoleIfExists(comment, objectName string) error
 	GrantUsersToRole(ctx context.Context, role string, users ...string) error
 	RevokeUsersFromRole(ctx context.Context, role string, users ...string) error
 	GrantRolesToRole(ctx context.Context, role string, roles ...string) error
@@ -664,7 +664,7 @@ func (s *AccessSyncer) generateAccessControls(ctx context.Context, apMap map[str
 		if _, f := existingRoles[rn]; f {
 			logger.Info(fmt.Sprintf("Merging role %q", rn))
 
-			err := repo.CommentIfExists(createComment(accessProvider, true), "ROLE", rn)
+			err := repo.CommentRoleIfExists(createComment(accessProvider, true), rn)
 			if err != nil {
 				return fmt.Errorf("error while updating comment on role %q: %s", rn, err.Error())
 			}
@@ -781,7 +781,7 @@ func (s *AccessSyncer) generateAccessControls(ctx context.Context, apMap map[str
 				}
 
 				// Updating the comment (independent of creation)
-				err = repo.CommentIfExists(createComment(accessProvider, false), "ROLE", rn)
+				err = repo.CommentRoleIfExists(createComment(accessProvider, false), rn)
 				if err != nil {
 					return fmt.Errorf("error while updating comment on role %q: %s", rn, err.Error())
 				}

--- a/snowflake/data_access_test.go
+++ b/snowflake/data_access_test.go
@@ -480,8 +480,8 @@ func TestAccessSyncer_SyncAccessProvidersToTarget(t *testing.T) {
 
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
 	repoMock.EXPECT().CreateRole("RoleName3").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName3").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName3").Return(nil).Once()
 
 	expectGrantUsersToRole(repoMock, "RoleName1", "User1", "User2")
 	expectGrantUsersToRole(repoMock, "RoleName3")
@@ -492,7 +492,7 @@ func TestAccessSyncer_SyncAccessProvidersToTarget(t *testing.T) {
 	repoMock.EXPECT().GetGrantsOfRole("ExistingRole1").Return([]GrantOfRole{}, nil).Once()
 	repoMock.EXPECT().GetGrantsToRole("ExistingRole1").Return([]GrantToRole{}, nil).Once()
 
-	repoMock.EXPECT().CommentIfExists(mock.Anything, "ROLE", "ExistingRole1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "ExistingRole1").Return(nil).Once()
 
 	repoMock.EXPECT().ExecuteGrant("USAGE", "DATABASE DB1", "RoleName1").Return(nil).Once()
 	repoMock.EXPECT().ExecuteGrant("USAGE", "SCHEMA DB1.Schema1", "RoleName1").Return(nil).Once()
@@ -612,7 +612,7 @@ func TestAccessSyncer_SyncAccessAsCodeToTarget(t *testing.T) {
 	}, nil).Once()
 
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
 	expectGrantUsersToRole(repoMock, "RoleName1", "User1", "User2")
 	repoMock.EXPECT().GrantRolesToRole(mock.Anything, "RoleName1").Return(nil).Once()
 
@@ -909,7 +909,7 @@ func generateAccessControls_table(t *testing.T) {
 	repoMock := newMockDataAccessRepository(t)
 
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
 	expectGrantUsersToRole(repoMock, "RoleName1", "User1", "User2")
 	repoMock.EXPECT().GrantRolesToRole(mock.Anything, "RoleName1").Return(nil).Once()
 
@@ -948,7 +948,7 @@ func generateAccessControls_view(t *testing.T) {
 	repoMock := newMockDataAccessRepository(t)
 
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
 	expectGrantUsersToRole(repoMock, "RoleName1", "User1", "User2")
 	repoMock.EXPECT().GrantRolesToRole(mock.Anything, "RoleName1").Return(nil).Once()
 
@@ -987,7 +987,7 @@ func generateAccessControls_schema(t *testing.T) {
 	repoMock := newMockDataAccessRepository(t)
 
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
 	expectGrantUsersToRole(repoMock, "RoleName1", "User1", "User2")
 	repoMock.EXPECT().GrantRolesToRole(mock.Anything, "RoleName1").Return(nil).Once()
 
@@ -1040,7 +1040,7 @@ func generateAccessControls_schema_nopropagate(t *testing.T) {
 	repoMock := newMockDataAccessRepository(t)
 
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
 	expectGrantUsersToRole(repoMock, "RoleName1", "User1", "User2")
 	repoMock.EXPECT().GrantRolesToRole(mock.Anything, "RoleName1").Return(nil).Once()
 
@@ -1080,7 +1080,7 @@ func generateAccessControls_schema_noverify(t *testing.T) {
 	repoMock := newMockDataAccessRepository(t)
 
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
 	expectGrantUsersToRole(repoMock, "RoleName1", "User1", "User2")
 	repoMock.EXPECT().GrantRolesToRole(mock.Anything, "RoleName1").Return(nil).Once()
 
@@ -1118,7 +1118,7 @@ func generateAccessControls_existing_schema(t *testing.T) {
 	//Given
 	repoMock := newMockDataAccessRepository(t)
 
-	repoMock.EXPECT().CommentIfExists(mock.AnythingOfType("string"), "ROLE", "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.AnythingOfType("string"), "RoleName1").Return(nil).Once()
 
 	repoMock.EXPECT().GetGrantsOfRole(mock.Anything).Return([]GrantOfRole{}, nil)
 	repoMock.EXPECT().GetGrantsToRole(mock.Anything).Return([]GrantToRole{}, nil)
@@ -1175,7 +1175,7 @@ func generateAccessControls_sharedDatabase(t *testing.T) {
 	repoMock := newMockDataAccessRepository(t)
 
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
 	expectGrantUsersToRole(repoMock, "RoleName1", "User1", "User2")
 	repoMock.EXPECT().GrantRolesToRole(mock.Anything, "RoleName1").Return(nil).Once()
 
@@ -1214,7 +1214,7 @@ func generateAccessControls_database(t *testing.T) {
 	repoMock := newMockDataAccessRepository(t)
 
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
 	expectGrantUsersToRole(repoMock, "RoleName1", "User1", "User2")
 	repoMock.EXPECT().GrantRolesToRole(mock.Anything, "RoleName1").Return(nil).Once()
 
@@ -1270,7 +1270,7 @@ func generateAccessControls_existing_database(t *testing.T) {
 	//Given
 	repoMock := newMockDataAccessRepository(t)
 
-	repoMock.EXPECT().CommentIfExists(mock.AnythingOfType("string"), "ROLE", "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.AnythingOfType("string"), "RoleName1").Return(nil).Once()
 
 	repoMock.EXPECT().GetGrantsOfRole(mock.Anything).Return([]GrantOfRole{}, nil)
 	repoMock.EXPECT().GetGrantsToRole(mock.Anything).Return([]GrantToRole{}, nil)
@@ -1333,7 +1333,7 @@ func generateAccessControls_warehouse(t *testing.T) {
 	repoMock := newMockDataAccessRepository(t)
 
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
 	expectGrantUsersToRole(repoMock, "RoleName1", "User1", "User2")
 	repoMock.EXPECT().GrantRolesToRole(mock.Anything, "RoleName1").Return(nil).Once()
 
@@ -1371,7 +1371,7 @@ func generateAccessControls_datasource(t *testing.T) {
 	repoMock := newMockDataAccessRepository(t)
 
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
 	expectGrantUsersToRole(repoMock, "RoleName1", "User1", "User2")
 	repoMock.EXPECT().GrantRolesToRole(mock.Anything, "RoleName1").Return(nil).Once()
 
@@ -1419,7 +1419,7 @@ func TestAccessSyncer_generateAccessControls_existingRole(t *testing.T) {
 	//Given
 	repoMock := newMockDataAccessRepository(t)
 
-	repoMock.EXPECT().CommentIfExists(mock.AnythingOfType("string"), "ROLE", "existingRole1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.AnythingOfType("string"), "existingRole1").Return(nil).Once()
 	repoMock.EXPECT().GetGrantsOfRole("existingRole1").Return([]GrantOfRole{
 		{GrantedTo: "USER", GranteeName: "User1"},
 		{GrantedTo: "USER", GranteeName: "User3"},
@@ -1473,9 +1473,9 @@ func TestAccessSyncer_generateAccessControls_inheritance(t *testing.T) {
 	repoMock.EXPECT().CreateRole("RoleName1").Return(nil).Once()
 	repoMock.EXPECT().CreateRole("RoleName2").Return(nil).Once()
 	repoMock.EXPECT().CreateRole("RoleName3").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName1").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName2").Return(nil).Once()
-	repoMock.EXPECT().CommentIfExists(mock.Anything, mock.Anything, "RoleName3").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName1").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName2").Return(nil).Once()
+	repoMock.EXPECT().CommentRoleIfExists(mock.Anything, "RoleName3").Return(nil).Once()
 	expectGrantUsersToRole(repoMock, "RoleName1")
 	expectGrantUsersToRole(repoMock, "RoleName2")
 	expectGrantUsersToRole(repoMock, "RoleName3", "User1")

--- a/snowflake/it/repository_integration_test.go
+++ b/snowflake/it/repository_integration_test.go
@@ -694,7 +694,7 @@ func (s *RepositoryTestSuite) TestSnowflakeRepository_CommentIfExists_NonExistin
 	roleName := fmt.Sprintf("%s_REPO_TEST_COMMENT_NON_EXISTING_ROLE", testId)
 
 	//When
-	err := s.repo.CommentIfExists("SomeComment", "ROLE", roleName)
+	err := s.repo.CommentRoleIfExists("SomeComment", roleName)
 
 	//Then
 	s.NoError(err)
@@ -708,7 +708,7 @@ func (s *RepositoryTestSuite) TestSnowflakeRepository_CommentIfExists_Role() {
 	comment := "Some comment"
 
 	//When
-	err = s.repo.CommentIfExists(comment, "ROLE", roleName)
+	err = s.repo.CommentRoleIfExists(comment, roleName)
 
 	//Then
 	s.NoError(err)

--- a/snowflake/mock_dataAccessRepository.go
+++ b/snowflake/mock_dataAccessRepository.go
@@ -63,13 +63,13 @@ func (_c *mockDataAccessRepository_Close_Call) RunAndReturn(run func() error) *m
 	return _c
 }
 
-// CommentIfExists provides a mock function with given fields: comment, objectType, objectName
-func (_m *mockDataAccessRepository) CommentIfExists(comment string, objectType string, objectName string) error {
-	ret := _m.Called(comment, objectType, objectName)
+// CommentRoleIfExists provides a mock function with given fields: comment, objectName
+func (_m *mockDataAccessRepository) CommentRoleIfExists(comment string, objectName string) error {
+	ret := _m.Called(comment, objectName)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
-		r0 = rf(comment, objectType, objectName)
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(comment, objectName)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -77,32 +77,31 @@ func (_m *mockDataAccessRepository) CommentIfExists(comment string, objectType s
 	return r0
 }
 
-// mockDataAccessRepository_CommentIfExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CommentIfExists'
-type mockDataAccessRepository_CommentIfExists_Call struct {
+// mockDataAccessRepository_CommentRoleIfExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CommentRoleIfExists'
+type mockDataAccessRepository_CommentRoleIfExists_Call struct {
 	*mock.Call
 }
 
-// CommentIfExists is a helper method to define mock.On call
+// CommentRoleIfExists is a helper method to define mock.On call
 //   - comment string
-//   - objectType string
 //   - objectName string
-func (_e *mockDataAccessRepository_Expecter) CommentIfExists(comment interface{}, objectType interface{}, objectName interface{}) *mockDataAccessRepository_CommentIfExists_Call {
-	return &mockDataAccessRepository_CommentIfExists_Call{Call: _e.mock.On("CommentIfExists", comment, objectType, objectName)}
+func (_e *mockDataAccessRepository_Expecter) CommentRoleIfExists(comment interface{}, objectName interface{}) *mockDataAccessRepository_CommentRoleIfExists_Call {
+	return &mockDataAccessRepository_CommentRoleIfExists_Call{Call: _e.mock.On("CommentRoleIfExists", comment, objectName)}
 }
 
-func (_c *mockDataAccessRepository_CommentIfExists_Call) Run(run func(comment string, objectType string, objectName string)) *mockDataAccessRepository_CommentIfExists_Call {
+func (_c *mockDataAccessRepository_CommentRoleIfExists_Call) Run(run func(comment string, objectName string)) *mockDataAccessRepository_CommentRoleIfExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string))
+		run(args[0].(string), args[1].(string))
 	})
 	return _c
 }
 
-func (_c *mockDataAccessRepository_CommentIfExists_Call) Return(_a0 error) *mockDataAccessRepository_CommentIfExists_Call {
+func (_c *mockDataAccessRepository_CommentRoleIfExists_Call) Return(_a0 error) *mockDataAccessRepository_CommentRoleIfExists_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *mockDataAccessRepository_CommentIfExists_Call) RunAndReturn(run func(string, string, string) error) *mockDataAccessRepository_CommentIfExists_Call {
+func (_c *mockDataAccessRepository_CommentRoleIfExists_Call) RunAndReturn(run func(string, string) error) *mockDataAccessRepository_CommentRoleIfExists_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/snowflake/repository.go
+++ b/snowflake/repository.go
@@ -558,12 +558,12 @@ func (repo *SnowflakeRepository) GetColumnsInDatabase(databaseName string, handl
 	}, handleEntity)
 }
 
-func (repo *SnowflakeRepository) CommentIfExists(comment, objectType, objectName string) error {
-	q := fmt.Sprintf(`COMMENT IF EXISTS ON %s %s IS '%s'`, objectType, common.FormatQuery("%s", objectName), comment)
+func (repo *SnowflakeRepository) CommentRoleIfExists(comment, objectName string) error {
+	q := fmt.Sprintf(`COMMENT IF EXISTS ON ROLE %s IS '%s'`, common.FormatQuery("%s", objectName), comment)
 	_, _, err := repo.query(q)
 
-	if err == nil || objectType != "ROLE" {
-		return err
+	if err == nil {
+		return nil
 	}
 
 	ownershipQuery := common.FormatQuery(`GRANT OWNERSHIP ON ROLE %s TO ROLE %s`, objectName, repo.role)

--- a/snowflake/repository.go
+++ b/snowflake/repository.go
@@ -559,7 +559,17 @@ func (repo *SnowflakeRepository) GetColumnsInDatabase(databaseName string, handl
 }
 
 func (repo *SnowflakeRepository) CommentIfExists(comment, objectType, objectName string) error {
-	q := fmt.Sprintf(`COMMENT IF EXISTS ON %s %s IS '%s'`, objectType, objectName, comment)
+	objectNameFormatted := common.FormatQuery("%s", objectName)
+	if objectType == "ROLE" {
+		q := common.FormatQuery(`GRANT OWNERSHIP ON ROLE %s TO ROLE %s`, objectNameFormatted, repo.role)
+		_, _, err := repo.query(q)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	q := fmt.Sprintf(`COMMENT IF EXISTS ON %s %s IS '%s'`, objectType, objectNameFormatted, comment)
 
 	_, _, err := repo.query(q)
 


### PR DESCRIPTION
I haven't tested it yet, since it will be 10x faster to test on our demo env. 

The general idea is that the ownership of a role needs to be set correctly if you want to alter a role
- This was already done for `DropRole` ✔️ 
- Not done for comments (hence the failures)
- For all the grants it's not necessary I think, and so I don't see any other place where we alter a role. We don't change the name of the roles. Anything I'm missing? 