### PR TITLE
Don't comment on existing role if not in full control

### DIFF
--- a/snowflake/data_access.go
+++ b/snowflake/data_access.go
@@ -742,9 +742,12 @@ func (s *AccessSyncer) handleAccessProvider(ctx context.Context, rn string, apMa
 	if _, f := existingRoles[rn]; f {
 		logger.Info(fmt.Sprintf("Merging role %q", rn))
 
-		err2 := repo.CommentRoleIfExists(createComment(accessProvider, true), rn)
-		if err2 != nil {
-			return fmt.Errorf("error while updating comment on role %q: %s", rn, err2.Error())
+		// Only update the comment if we have full control over the role (who and what not ignored)
+		if !ignoreWho && !ignoreWhat {
+			err2 := repo.CommentRoleIfExists(createComment(accessProvider, true), rn)
+			if err2 != nil {
+				return fmt.Errorf("error while updating comment on role %q: %s", rn, err2.Error())
+			}
 		}
 
 		if !ignoreWho || !ignoreInheritance {


### PR DESCRIPTION
Telenet saw that we took ownership of the roles, but in their case they are created by Terraform and the ownership should stay there. We don't need the ownership if we only need to create the inheritance hierarchy.