### PR TITLE
Improved resilience when AP import fails

### DIFF
--- a/snowflake/data_access_sync_from_target.go
+++ b/snowflake/data_access_sync_from_target.go
@@ -48,7 +48,7 @@ func (s *AccessSyncer) importAllRolesOnAccountLevel(accessProviderHandler wrappe
 
 		err = s.transformAccountRoleToAccessProvider(roleEntity, processedAps, linkToExternalIdentityStoreGroups, *tagRetrieval, externalGroupOwners, shares, repo)
 		if err != nil {
-			return err
+			logger.Warn(fmt.Sprintf("Error importing SnowFlake role %q: %s"+roleEntity.Name, err.Error()))
 		}
 	}
 
@@ -202,9 +202,9 @@ func (s *AccessSyncer) importAllRolesOnDatabaseLevel(accessProviderHandler wrapp
 				continue
 			}
 
-			err = s.importAccessForDatabaseRole(database.Name, roleEntity, externalGroupOwners, linkToExternalIdentityStoreGroups, *tagRetrieval, repo, processedAps, shares)
-			if err != nil {
-				return err
+			err2 := s.importAccessForDatabaseRole(database.Name, roleEntity, externalGroupOwners, linkToExternalIdentityStoreGroups, *tagRetrieval, repo, processedAps, shares)
+			if err2 != nil {
+				logger.Warn(fmt.Sprintf("Error importing SnowFlake Database role %q: %s", fullRoleName, err2.Error()))
 			}
 		}
 

--- a/snowflake/data_access_sync_to_target.go
+++ b/snowflake/data_access_sync_to_target.go
@@ -382,28 +382,27 @@ func (s *AccessSyncer) importPoliciesOfType(accessProviderHandler wrappers.Acces
 		}
 
 		// get policy definition
-		desribeMaskingPolicyEntities, err := repo.DescribePolicy(policyType, policy.DatabaseName, policy.SchemaName, policy.Name)
-		if err != nil {
-			logger.Error(err.Error())
+		describeMaskingPolicyEntities, err2 := repo.DescribePolicy(policyType, policy.DatabaseName, policy.SchemaName, policy.Name)
+		if err2 != nil {
+			logger.Warn(fmt.Sprintf("Error fetching description for policy %s.%s.%s: %s", policy.DatabaseName, policy.SchemaName, policy.Name, err2.Error()))
 
-			return err
+			continue
 		}
 
-		if len(desribeMaskingPolicyEntities) != 1 {
-			err = fmt.Errorf("found %d definitions for %s policy %s.%s.%s, only expecting one", len(desribeMaskingPolicyEntities), policyType, policy.DatabaseName, policy.SchemaName, policy.Name)
-			logger.Error(err.Error())
+		if len(describeMaskingPolicyEntities) != 1 {
+			logger.Warn(fmt.Sprintf("Found %d definitions for %s policy %s.%s.%s, only expecting one", len(describeMaskingPolicyEntities), policyType, policy.DatabaseName, policy.SchemaName, policy.Name))
 
-			return err
+			continue
 		}
 
-		ap.Policy = desribeMaskingPolicyEntities[0].Body
+		ap.Policy = describeMaskingPolicyEntities[0].Body
 
 		// get policy references
-		policyReferenceEntities, err := repo.GetPolicyReferences(policy.DatabaseName, policy.SchemaName, policy.Name)
-		if err != nil {
-			logger.Error(err.Error())
+		policyReferenceEntities, err2 := repo.GetPolicyReferences(policy.DatabaseName, policy.SchemaName, policy.Name)
+		if err2 != nil {
+			logger.Warn(fmt.Sprintf("Error fetching policy references for %s.%s.%s: %s", policy.DatabaseName, policy.SchemaName, policy.Name, err2.Error()))
 
-			return fmt.Errorf("error fetching %s policy references: %s", policyType, err.Error())
+			continue
 		}
 
 		for ind := range policyReferenceEntities {
@@ -431,9 +430,9 @@ func (s *AccessSyncer) importPoliciesOfType(accessProviderHandler wrappers.Acces
 			})
 		}
 
-		err = accessProviderHandler.AddAccessProviders(&ap)
-		if err != nil {
-			return fmt.Errorf("error adding access provider to import file: %s", err.Error())
+		err2 = accessProviderHandler.AddAccessProviders(&ap)
+		if err2 != nil {
+			return fmt.Errorf("error adding access provider to import file: %s", err2.Error())
 		}
 	}
 

--- a/snowflake/data_access_sync_to_target_test.go
+++ b/snowflake/data_access_sync_to_target_test.go
@@ -617,46 +617,6 @@ func TestAccessSyncer_importPoliciesOfType(t *testing.T) {
 
 }
 
-func TestAccessSyncer_importPoliciesOfType_ErrorOnDescribePolicy(t *testing.T) {
-	//Given
-	repoMock := newMockDataAccessRepository(t)
-	fileCreator := mocks.NewSimpleAccessProviderHandler(t, 1)
-
-	policyType := "policyType"
-
-	repoMock.EXPECT().GetPolicies(policyType).Return([]PolicyEntity{
-		{
-			Name:         "Policy1",
-			Owner:        "PolicyOwner",
-			Kind:         policyType,
-			DatabaseName: "DB1",
-			SchemaName:   "Schema1",
-		},
-	}, nil).Once()
-
-	repoMock.EXPECT().DescribePolicy(policyType, "DB1", "Schema1", "Policy1").Return([]DescribePolicyEntity{
-		{
-			Name: "Policy1",
-			Body: "PolicyBody1",
-		},
-		{
-			Name: "BadPolicy1",
-			Body: "PolicyBody1",
-		},
-	}, nil).Once()
-
-	syncer := createBasicAccessSyncer(func(params map[string]string, role string) (dataAccessRepository, error) {
-		return nil, nil
-	})
-
-	//When
-	err := syncer.importPoliciesOfType(fileCreator, repoMock, policyType, sync_from_target.Grant)
-
-	//Then
-	assert.Error(t, err)
-	assert.Empty(t, fileCreator.AccessProviders)
-}
-
 func generateAccessControls_table(t *testing.T) {
 	//Given
 	repoMock := newMockDataAccessRepository(t)


### PR DESCRIPTION
When the reading of an individual role or policy fails, we don't fail the entire sync.