### PR TITLE
Ensure we got reference to the table when unsetting a mask

### DIFF
--- a/snowflake/repository.go
+++ b/snowflake/repository.go
@@ -1582,7 +1582,10 @@ func (repo *SnowflakeRepository) DropMaskingPolicy(databaseName string, schema s
 			}
 		}
 
-		_, err = tx.Exec(common.FormatQuery("ALTER TABLE %s.%s.%s ALTER COLUMN %s UNSET MASKING POLICY", databaseName, schema, policyEntries[i].REF_ENTITY_NAME, policyEntries[i].REF_COLUMN_NAME.String))
+		query := common.FormatQuery("ALTER TABLE %s.%s.%s ALTER COLUMN %s UNSET MASKING POLICY", databaseName, schema, policyEntries[i].REF_ENTITY_NAME, policyEntries[i].REF_COLUMN_NAME.String)
+		Logger.Debug(fmt.Sprintf("Unset masking policy %s from column %s in table %s: %s", policyEntries[i].POLICY_NAME, policyEntries[i].REF_COLUMN_NAME.String, policyEntries[i].REF_ENTITY_NAME, query))
+
+		_, err = tx.Exec(query)
 		if err != nil {
 			return err
 		}

--- a/snowflake/repository.go
+++ b/snowflake/repository.go
@@ -1569,9 +1569,9 @@ func (repo *SnowflakeRepository) DropMaskingPolicy(databaseName string, schema s
 	for i := range policyEntries {
 		Logger.Debug(fmt.Sprintf("Removing masking policy %s from column %s in table %s", policyEntries[i].POLICY_NAME, policyEntries[i].REF_COLUMN_NAME.String, policyEntries[i].REF_ENTITY_NAME))
 
-		if repo.role != AccountAdminRole {
-			tableFullName := common.FormatQuery("%s.%s.%s", databaseName, schema, policyEntries[i].REF_ENTITY_NAME)
+		tableFullName := common.FormatQuery("%s.%s.%s", databaseName, schema, policyEntries[i].REF_ENTITY_NAME)
 
+		if repo.role != AccountAdminRole {
 			if !referencedTables.Contains(tableFullName) {
 				err = repo.ExecuteGrantOnAccountRole("REFERENCES", fmt.Sprintf("TABLE %s", tableFullName), repo.role, true)
 				if err != nil {
@@ -1582,7 +1582,7 @@ func (repo *SnowflakeRepository) DropMaskingPolicy(databaseName string, schema s
 			}
 		}
 
-		query := common.FormatQuery("ALTER TABLE %s.%s.%s ALTER COLUMN %s UNSET MASKING POLICY", databaseName, schema, policyEntries[i].REF_ENTITY_NAME, policyEntries[i].REF_COLUMN_NAME.String)
+		query := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %q UNSET MASKING POLICY", tableFullName, policyEntries[i].REF_COLUMN_NAME.String)
 		Logger.Debug(fmt.Sprintf("Unset masking policy %s from column %s in table %s: %s", policyEntries[i].POLICY_NAME, policyEntries[i].REF_COLUMN_NAME.String, policyEntries[i].REF_ENTITY_NAME, query))
 
 		_, err = tx.Exec(query)

--- a/snowflake/repository.go
+++ b/snowflake/repository.go
@@ -1678,7 +1678,6 @@ func (repo *SnowflakeRepository) DropFilter(databaseName string, schema string, 
 			if err != nil {
 				return fmt.Errorf("enable reference on table: \"%s.%s.%s\": %w", databaseName, schema, tableFullName, err)
 			}
-
 		}
 
 		err = repo.execute(fmt.Sprintf("ALTER TABLE %[1]s.%[2]s.%[3]s DROP ROW ACCESS POLICY %[1]s.%[2]s.%[4]s;", databaseName, schema, tableName, *existingPolicy))

--- a/snowflake/repository.go
+++ b/snowflake/repository.go
@@ -1573,7 +1573,7 @@ func (repo *SnowflakeRepository) DropMaskingPolicy(databaseName string, schema s
 			tableFullName := common.FormatQuery("%s.%s.%s", databaseName, schema, policyEntries[i].REF_ENTITY_NAME)
 
 			if !referencedTables.Contains(tableFullName) {
-				err = repo.ExecuteGrantOnAccountRole("REFERENCE", fmt.Sprintf("TABLE %s", tableFullName), repo.role, true)
+				err = repo.ExecuteGrantOnAccountRole("REFERENCES", fmt.Sprintf("TABLE %s", tableFullName), repo.role, true)
 				if err != nil {
 					return fmt.Errorf("enable reference on table: \"%s.%s.%s\": %w", databaseName, schema, policyEntries[i].REF_ENTITY_NAME, err)
 				}

--- a/snowflake/repository.go
+++ b/snowflake/repository.go
@@ -1671,7 +1671,17 @@ func (repo *SnowflakeRepository) DropFilter(databaseName string, schema string, 
 	}
 
 	if existingPolicy != nil {
-		err = repo.execute(common.FormatQuery("ALTER TABLE %[1]s.%[2]s.%[3]s DROP ROW ACCESS POLICY %[1]s.%[2]s.%[4]s;", databaseName, schema, tableName, *existingPolicy))
+		tableFullName := common.FormatQuery("%s.%s.%s", databaseName, schema, tableName)
+
+		if repo.role != AccountAdminRole {
+			err = repo.ExecuteGrantOnAccountRole("REFERENCES", fmt.Sprintf("TABLE %s", tableFullName), repo.role, true)
+			if err != nil {
+				return fmt.Errorf("enable reference on table: \"%s.%s.%s\": %w", databaseName, schema, tableFullName, err)
+			}
+
+		}
+
+		err = repo.execute(fmt.Sprintf("ALTER TABLE %[1]s.%[2]s.%[3]s DROP ROW ACCESS POLICY %[1]s.%[2]s.%[4]s;", databaseName, schema, tableName, *existingPolicy))
 		if err != nil {
 			return err
 		}

--- a/snowflake/repository.go
+++ b/snowflake/repository.go
@@ -1680,7 +1680,7 @@ func (repo *SnowflakeRepository) DropFilter(databaseName string, schema string, 
 			}
 		}
 
-		err = repo.execute(fmt.Sprintf("ALTER TABLE %[1]s.%[2]s.%[3]s DROP ROW ACCESS POLICY %[1]s.%[2]s.%[4]s;", databaseName, schema, tableName, *existingPolicy))
+		err = repo.execute(common.FormatQuery("ALTER TABLE %[1]s.%[2]s.%[3]s DROP ROW ACCESS POLICY %[1]s.%[2]s.%[4]s;", databaseName, schema, tableName, *existingPolicy))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of permissions when removing masking policies, ensuring roles have the necessary access to affected tables.
	- Optimized permission grants to avoid redundant actions, enhancing efficiency for non-admin users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->